### PR TITLE
Check out code before setting up go

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,13 +18,13 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
         go-version: stable
-
-    - name: Checkout code
-      uses: actions/checkout@v3
 
     - name: Checkout wiki
       uses: actions/checkout@v3


### PR DESCRIPTION
Enable caching by checking out the code before setting up go@v4.  See https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs for details.