### PR TITLE
Add chart-show-diff-only flag to collapse the equal coverage results

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ The action has 8 configuration knobs:
   generate an [HTML coverage report][1].
 - `chart`: default `false`,
   generate an [SVG coverage chart][4].
+- `chart-show-diff-only`: default `false`,
+  collapse the same coverage results into single point in the [SVG coverage chart][4].
 - `amend`: default `false`,
   amend your Wiki, avoiding a series of “Update coverage” commits.
 - `reuse-go`: default `false`,

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,9 @@ inputs:
   chart:
     description: Generate a coverage over time chart.
     default: false
+  chart-show-diff-only:
+    description: Collapse the same coverage results into single point on the chart.
+    default: false
   amend:
     description: Amend wiki, avoiding spurious commits.
     default: false
@@ -53,6 +56,7 @@ runs:
         INPUT_COVERAGE: ${{inputs.coverage-file}}
         INPUT_REPORT: ${{inputs.report}}
         INPUT_CHART: ${{inputs.chart}}
+        INPUT_CHART_SHOW_DIFF_ONLY: ${{inputs.chart-show-diff-only}}
         INPUT_BADGE_STYLE: ${{inputs.badge-style}}
         INPUT_BADGE_TITLE: ${{inputs.badge-title}}
       run: |

--- a/coverage.sh
+++ b/coverage.sh
@@ -53,8 +53,13 @@ curl -s "https://img.shields.io/badge/$(printf %s "$TITLE" | jq -sRr @uri)-$COVE
 if [[ "${INPUT_CHART-false}" == "true" ]]; then
 	GRADIENT='getGradientFillHelper("vertical",["#44CC11","#97CA00","#A4A61D","#DFB317","#FE7D37","#E05D44"])'
 
+	coverageLog=$(cat "$OUTPUT/coverage.log")
+	if [[ "${INPUT_CHART_SHOW_DIFF_ONLY-false}" == "true" ]]; then
+		# collapse equal results, but save first and last points
+		coverageLog=$(echo "$coverageLog" | awk -F ',' '{ if (NR==1 || $2 != prev) { print; prev = $2 } } END { print }')
+	fi
 	jq -csf "$DIR/chart.jq" "$DIR/chart.json" <(
-		tail -n 20 "$OUTPUT/coverage.log" | sed 's/.*/[&]/' | jq -s '.|transpose'
+		echo "$coverageLog" | tail -n 20 | sed 's/.*/[&]/' | jq -s '.|transpose'
 	) |
 	sed s/\"__GRADIENT__\"/"$GRADIENT"/ |
 	jq -csR '{format:"svg", chart:.}' |


### PR DESCRIPTION
As a user of the action I want to avoid the loosing my coverage changes chart in case when I push 20+ commits with the same coverage value