### PR TITLE
Deprecate reuse-go.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,6 @@ The action has 8 configuration knobs:
   generate an [SVG coverage chart][4].
 - `amend`: default `false`,
   amend your Wiki, avoiding a series of “Update coverage” commits.
-- `reuse-go`: default `false`,
-  reuse Go as setup by the caller action
-  (for performance, caching, configurability).
 
 Also, consider:
 - running this step _after_ your tests run
@@ -55,7 +52,6 @@ Complete example:
     report: true
     chart: true
     amend: true
-    reuse-go: true
   if: |
     matrix.os == 'ubuntu-latest' &&
     github.event_name == 'push'  

--- a/action.yml
+++ b/action.yml
@@ -25,8 +25,7 @@ inputs:
     description: Amend wiki, avoiding spurious commits.
     default: false
   reuse-go:
-    description: Reuse Go as setup by the caller action.
-    default: false
+    deprecationMessage: Go install is always reused.
 
 runs:
   using: composite
@@ -42,10 +41,6 @@ runs:
       with:
         repository: ${{github.repository}}.wiki
         path: ./.github/wiki/
-
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      if: inputs.reuse-go != 'true'
 
     - name: Generate coverage report
       shell: bash


### PR DESCRIPTION
GitHub runners always have _some_ Go installed, so let's just use that.
If people want to configure Go, they already had to in the parent action.