### PR TITLE
Add new option base-dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The action has 8 configuration knobs:
   generate an [SVG coverage chart][4].
 - `amend`: default `false`,
   amend your Wiki, avoiding a series of “Update coverage” commits.
+- `base-dir`: default `.`,
+  base directory within which to run `go tool cover`
 
 Also, consider:
 - running this step _after_ your tests run

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,9 @@ inputs:
     default: false
   reuse-go:
     deprecationMessage: Go install is always reused.
+  base-dir:
+    description: base directory within which to run `go tool cover`
+    default: .
 
 runs:
   using: composite
@@ -34,7 +37,7 @@ runs:
       uses: actions/checkout@v4
       if: |
         hashFiles('.github') == '' &&
-        inputs.coverage-file == ''        
+        inputs.coverage-file == ''
 
     - name: Checkout wiki
       uses: actions/checkout@v4
@@ -50,6 +53,7 @@ runs:
         INPUT_CHART: ${{inputs.chart}}
         INPUT_BADGE_STYLE: ${{inputs.badge-style}}
         INPUT_BADGE_TITLE: ${{inputs.badge-title}}
+        INPUT_BASE_DIR: ${{inputs.base-dir}}
       run: |
         ${{github.action_path}}/coverage.sh ./.github/wiki/${{inputs.output-dir}}
 

--- a/coverage.sh
+++ b/coverage.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 INPUT="${INPUT_COVERAGE-}"
-OUTPUT="$1"
+OUTPUT="$(pwd)/$1"
+INPUT_BASE_DIR="${INPUT_BASE_DIR-}"
 
 mkdir -p "$OUTPUT"
 
@@ -15,7 +16,7 @@ fi
 
 # Create an HTML report.
 if [[ "${INPUT_REPORT-true}" == "true" ]]; then
-	go tool cover -html="$INPUT" -o "$OUTPUT/coverage.html"
+	cd $INPUT_BASE_DIR && go tool cover -html="$INPUT" -o "$OUTPUT/coverage.html"
 fi
 
 # Extract total coverage: the decimal number from the last line of the function report.


### PR DESCRIPTION
This tool won't run in a repository containing multiple modules outside the repository root.
https://github.com/pantopic/wazero-lmdb/actions/runs/15812017725/job/44564557551
```
Run /home/runner/work/_actions/ncruces/go-coverage-report/v0.3.0/coverage.sh ./.github/wiki/
cover: no required module provides package github.com/pantopic/wazero-lmdb/host: go.mod file not found in current directory or any parent directory; see 'go help modules'
Error: Process completed with exit code 1.
```

This PR adds a new option `base-dir` to run `go tool cover` in the correct directory so it doesn't fail.

See example repo: https://github.com/pantopic/wazero-lmdb